### PR TITLE
Updates from the sever side, and fix memory leak for all

### DIFF
--- a/src/build.h.in
+++ b/src/build.h.in
@@ -118,10 +118,10 @@
 
 
 /** The default handshake interval */
-#define DEFAULT_HANDSHAKE_INTERVAL 20000 /* 20 seconds */
+#define DEFAULT_HANDSHAKE_INTERVAL 120000 /* 20 seconds */
 
 /** The default handshake interval jitter */
-#define DEFAULT_HANDSHAKE_JITTER 2500	/* 2.5 seconds */
+#define DEFAULT_HANDSHAKE_JITTER 25000	/* 25 seconds */
 
 /** The interval of periodic maintenance tasks */
 #define MAINTENANCE_INTERVAL 10000	/* 10 seconds */

--- a/src/config.c
+++ b/src/config.c
@@ -69,6 +69,7 @@ static void default_config(void) {
 	conf.mode = MODE_TAP;
 	conf.iface_persist = true;
     conf.keepalive_sync = false;
+    conf.keepalive_time = KEEPALIVE_TIMEOUT;
 
 	conf.secure_handshakes = true;
 	conf.drop_caps = DROP_CAPS_ON;

--- a/src/config.y
+++ b/src/config.y
@@ -127,6 +127,7 @@
 %token TOK_SYNC
 %token TOK_SYSLOG
 %token TOK_TAP
+%token TOK_TIME
 %token TOK_TO
 %token TOK_TUN
 %token TOK_UP
@@ -295,6 +296,10 @@ persist:	TOK_INTERFACE boolean {
 
 keepalive:	TOK_SYNC boolean {
 			conf.keepalive_sync = $2;
+		}
+	|		TOK_TIME TOK_UINT {
+			conf.keepalive_time = $2;
+			printf("Setting keep alive to: %ld\n", conf.keepalive_time);
 		}
 	;
 

--- a/src/fastd.h
+++ b/src/fastd.h
@@ -359,7 +359,7 @@ extern fastd_config_t conf;
 void fastd_send(const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr, fastd_peer_t *peer, fastd_buffer_t buffer, size_t stat_size);
 void fastd_send_handshake(const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr, fastd_peer_t *peer, fastd_buffer_t buffer);
 void fastd_send_data(fastd_buffer_t buffer, fastd_peer_t *source, fastd_peer_t *dest);
-
+void fastd_send_keepalive_request(const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr, fastd_peer_t *peer);
 void fastd_receive_unknown_init(void);
 void fastd_receive_unknown_free(void);
 void fastd_receive(fastd_socket_t *sock);

--- a/src/fastd.h
+++ b/src/fastd.h
@@ -360,11 +360,13 @@ void fastd_send(const fastd_socket_t *sock, const fastd_peer_address_t *local_ad
 void fastd_send_handshake(const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr, fastd_peer_t *peer, fastd_buffer_t buffer);
 void fastd_send_data(fastd_buffer_t buffer, fastd_peer_t *source, fastd_peer_t *dest);
 void fastd_send_keepalive_request(const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr, fastd_peer_t *peer);
+void fastd_send_keepalive_reply(const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr, fastd_peer_t *peer);
 void fastd_receive_unknown_init(void);
 void fastd_receive_unknown_free(void);
 void fastd_receive(fastd_socket_t *sock);
 void fastd_handle_receive(fastd_peer_t *peer, fastd_buffer_t buffer, bool reordered);
-void fastd_handle_receive_keepalive(fastd_peer_t *peer);
+void fastd_handle_receive_keepalive_reply(fastd_peer_t *peer);
+void fastd_handle_receive_keepalive_request(fastd_peer_t *peer);
 
 void fastd_close_all_fds(void);
 

--- a/src/fastd.h
+++ b/src/fastd.h
@@ -221,7 +221,7 @@ struct fastd_config {
 	bool forward;				/**< Specifies if packet forwarding is enable */
 	bool secure_handshakes;			/**< Can be set to false to support connections with fastd versions before v11 */
 	bool keepalive_sync;			/**< Specifies if we should send a handshake on receving one.  This can save power on mobile devices. */
-
+	fastd_timeout_t keepalive_time; /**< Specifies the time between keepalives */
 	fastd_drop_caps_t drop_caps;		/**< Specifies if and when to drop capabilities */
 
 #ifdef USE_USER

--- a/src/lex.c
+++ b/src/lex.c
@@ -123,6 +123,7 @@ static const keyword_t keywords[] = {
 	{ "sync", TOK_SYNC },
 	{ "syslog", TOK_SYSLOG },
 	{ "tap", TOK_TAP },
+	{ "time", TOK_TIME },
 	{ "to", TOK_TO },
 	{ "tun", TOK_TUN },
 	{ "up", TOK_UP },

--- a/src/peer.c
+++ b/src/peer.c
@@ -677,20 +677,25 @@ bool fastd_peer_claim_address(fastd_peer_t *new_peer, fastd_socket_t *sock, cons
 	return true;
 }
 
-/** Sends a keep alive now and resets the timer */
-void fastd_peer_send_keepalive(fastd_peer_t *peer) {
+/** Sends a keep alive request and resets periodic timer */
+void fastd_peer_send_keepalive_request(fastd_peer_t *peer) {
 	if (peer->state == STATE_ESTABLISHED) {
-		int64_t last = peer->keepalive_timeout - ctx.now;
-		if (last > 0 && last < 3000) {
-			pr_debug("Skipping keepalive last sent < 3s ago to peer: %P", peer);
-			return;
-		}
-		pr_debug("triggering a keepalive peer %P", peer);
-		fastd_peer_force_keepalive(peer);
+		pr_debug("triggering a keepalive request peer %P", peer);
+		fastd_peer_clear_keepalive(peer);
+		fastd_send_keepalive_request(peer->sock, &peer->local_address, &peer->address, peer);
 		schedule_peer_task(peer);
 	}
 }
 
+/** Sends a keep alive now and resets the timer */
+void fastd_peer_send_keepalive_reply(fastd_peer_t *peer) {
+	if (peer->state == STATE_ESTABLISHED) {
+		pr_debug("triggering a keepalive reply for peer %P", peer);
+		fastd_send_keepalive_reply(peer->sock, &peer->local_address, &peer->address, peer);
+		fastd_peer_clear_keepalive(peer);
+		schedule_peer_task(peer);
+	}
+}
 /** Resets and re-initializes a peer */
 void fastd_peer_reset(fastd_peer_t *peer) {
 	if (peer->state != STATE_INACTIVE) {
@@ -1057,7 +1062,7 @@ void fastd_peer_trigger_keepalives_all(void) {
 	size_t i;
 	for (i = 0; i < VECTOR_LEN(ctx.peers);) {
 		fastd_peer_t *peer = VECTOR_INDEX(ctx.peers, i);
-		fastd_peer_send_keepalive(peer);
+		fastd_peer_send_keepalive_request(peer);
 		i++;
 	}
 }

--- a/src/peer.h
+++ b/src/peer.h
@@ -262,15 +262,17 @@ static inline void fastd_peer_seen(fastd_peer_t *peer) {
 	peer->reset_timeout = ctx.now + PEER_STALE_TIME;
 }
 
-/** Sets the keepalive timeout to now */
-static inline void fastd_peer_force_keepalive(fastd_peer_t *peer) {
-	peer->keepalive_timeout = ctx.now;
-}
-
 /** Resets the keepalive timeout */
 static inline void fastd_peer_clear_keepalive(fastd_peer_t *peer) {
-	peer->keepalive_timeout = ctx.now + KEEPALIVE_TIMEOUT;
+	peer->keepalive_timeout = ctx.now + conf.keepalive_time;
 }
+
+/** Sets the keepalive timeout to now */
+static inline void fastd_peer_force_keepalive(fastd_peer_t *peer) {
+	fastd_peer_clear_keepalive(peer);
+	fastd_send_keepalive_request(peer->sock, &peer->local_address, &peer->address, peer);
+}
+
 
 /** Checks if a peer uses dynamic sockets (which means that each connection attempt uses a new socket) */
 static inline bool fastd_peer_is_socket_dynamic(const fastd_peer_t *peer) {

--- a/src/peer.h
+++ b/src/peer.h
@@ -158,7 +158,8 @@ void fastd_peer_handle_task(fastd_task_t *task);
 void fastd_peer_eth_addr_cleanup(void);
 void fastd_peer_reset_all(void);
 void fastd_peer_trigger_keepalives_all(void);
-void fastd_peer_send_keepalive(fastd_peer_t *peer);
+void fastd_peer_send_keepalive_request(fastd_peer_t *peer);
+void fastd_peer_send_keepalive_reply(fastd_peer_t *peer);
 
 /** Returns the port of a fastd_peer_address_t (in network byte order) */
 static inline uint16_t fastd_peer_address_get_port(const fastd_peer_address_t *addr) {
@@ -259,6 +260,7 @@ static inline bool fastd_peer_is_established(const fastd_peer_t *peer) {
 
 /** Signals that a valid packet was received from the peer */
 static inline void fastd_peer_seen(fastd_peer_t *peer) {
+    pr_debug("Marking peer seen %P", peer);
 	peer->reset_timeout = ctx.now + PEER_STALE_TIME;
 }
 
@@ -266,13 +268,6 @@ static inline void fastd_peer_seen(fastd_peer_t *peer) {
 static inline void fastd_peer_clear_keepalive(fastd_peer_t *peer) {
 	peer->keepalive_timeout = ctx.now + conf.keepalive_time;
 }
-
-/** Sets the keepalive timeout to now */
-static inline void fastd_peer_force_keepalive(fastd_peer_t *peer) {
-	fastd_peer_clear_keepalive(peer);
-	fastd_send_keepalive_request(peer->sock, &peer->local_address, &peer->address, peer);
-}
-
 
 /** Checks if a peer uses dynamic sockets (which means that each connection attempt uses a new socket) */
 static inline bool fastd_peer_is_socket_dynamic(const fastd_peer_t *peer) {

--- a/src/protocols/ec25519_fhmqvc/ec25519_fhmqvc.c
+++ b/src/protocols/ec25519_fhmqvc/ec25519_fhmqvc.c
@@ -166,7 +166,6 @@ static void protocol_handle_recv(fastd_peer_t *peer, fastd_buffer_t buffer) {
 		fastd_handle_receive(peer, recv_buffer, reordered);
 	}
 	else {
-		fastd_handle_receive_keepalive(peer);
 		fastd_buffer_free(recv_buffer);
 	}
 

--- a/src/receive.c
+++ b/src/receive.c
@@ -189,9 +189,11 @@ static inline void handle_socket_receive_known(fastd_socket_t *sock, const fastd
 		break;
 	case PACKET_KEEPALIVE_REQUEST:
 		fastd_handle_receive_keepalive_request(peer);
+		fastd_buffer_free(buffer);
 		break;
 	case PACKET_KEEPALIVE_REPLY:
 		fastd_handle_receive_keepalive_reply(peer);
+		fastd_buffer_free(buffer);
 		break;
 	}
 }

--- a/src/receive.c
+++ b/src/receive.c
@@ -186,6 +186,10 @@ static inline void handle_socket_receive_known(fastd_socket_t *sock, const fastd
 
 	case PACKET_HANDSHAKE:
 		fastd_handshake_handle(sock, local_addr, remote_addr, peer, buffer);
+		break;
+	case PACKET_KEEPALIVE_REQUEST:
+		fastd_handle_receive_keepalive(peer);
+		break;
 	}
 }
 

--- a/src/receive.c
+++ b/src/receive.c
@@ -188,7 +188,10 @@ static inline void handle_socket_receive_known(fastd_socket_t *sock, const fastd
 		fastd_handshake_handle(sock, local_addr, remote_addr, peer, buffer);
 		break;
 	case PACKET_KEEPALIVE_REQUEST:
-		fastd_handle_receive_keepalive(peer);
+		fastd_handle_receive_keepalive_request(peer);
+		break;
+	case PACKET_KEEPALIVE_REPLY:
+		fastd_handle_receive_keepalive_reply(peer);
 		break;
 	}
 }
@@ -320,13 +323,16 @@ void fastd_handle_receive(fastd_peer_t *peer, fastd_buffer_t buffer, bool reorde
 	fastd_buffer_free(buffer);
 }
 
-/** Handles a receveid keepalive, there is no payload */
-void fastd_handle_receive_keepalive(fastd_peer_t *peer) {
-    pr_debug("Got keepalive from peer %P", peer);
-    if (conf.keepalive_sync) {
-        pr_debug("Doing keepalive sync for %P", peer);
-        fastd_peer_send_keepalive(peer);
-    }
+/** Handles a received keepalive, there is no payload */
+void fastd_handle_receive_keepalive_request(fastd_peer_t *peer) {
+    pr_debug("Got keepalive request from peer %P", peer);
+    fastd_peer_seen(peer);
+    fastd_peer_send_keepalive_reply(peer);
 }
 
+/** Handles a received keepalive reply, there is no payload */
+void fastd_handle_receive_keepalive_reply(fastd_peer_t *peer) {
+    pr_debug("Got keepalive reply from peer %P", peer);
+    fastd_peer_seen(peer);
+}
 

--- a/src/receive.c
+++ b/src/receive.c
@@ -195,6 +195,9 @@ static inline void handle_socket_receive_known(fastd_socket_t *sock, const fastd
 		fastd_handle_receive_keepalive_reply(peer);
 		fastd_buffer_free(buffer);
 		break;
+	default:
+		fastd_buffer_free(buffer);
+		break;
 	}
 }
 

--- a/src/send.c
+++ b/src/send.c
@@ -184,6 +184,12 @@ void fastd_send_handshake(const fastd_socket_t *sock, const fastd_peer_address_t
 	send_type(sock, local_addr, remote_addr, peer, PACKET_HANDSHAKE, buffer, 0);
 }
 
+/** Sends a keepalive_req packet */
+void fastd_send_keepalive_request(const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr, fastd_peer_t *peer) {
+	fastd_buffer_t buffer = fastd_buffer_alloc(0, conf.min_encrypt_head_space, conf.min_encrypt_tail_space);
+	send_type(sock, local_addr, remote_addr, peer, PACKET_KEEPALIVE_REQUEST, buffer, 0);
+}
+
 /** Encrypts and sends a payload packet to all peers */
 static inline void send_all(fastd_buffer_t buffer, fastd_peer_t *source) {
 	size_t i;

--- a/src/send.c
+++ b/src/send.c
@@ -189,6 +189,11 @@ void fastd_send_keepalive_request(const fastd_socket_t *sock, const fastd_peer_a
 	fastd_buffer_t buffer = fastd_buffer_alloc(0, conf.min_encrypt_head_space, conf.min_encrypt_tail_space);
 	send_type(sock, local_addr, remote_addr, peer, PACKET_KEEPALIVE_REQUEST, buffer, 0);
 }
+/** Sends a keepalive_reply packet */
+void fastd_send_keepalive_reply(const fastd_socket_t *sock, const fastd_peer_address_t *local_addr, const fastd_peer_address_t *remote_addr, fastd_peer_t *peer) {
+	fastd_buffer_t buffer = fastd_buffer_alloc(0, conf.min_encrypt_head_space, conf.min_encrypt_tail_space);
+	send_type(sock, local_addr, remote_addr, peer, PACKET_KEEPALIVE_REPLY, buffer, 0);
+}
 
 /** Encrypts and sends a payload packet to all peers */
 static inline void send_all(fastd_buffer_t buffer, fastd_peer_t *source) {

--- a/src/types.h
+++ b/src/types.h
@@ -60,6 +60,7 @@ typedef struct fastd_tristate {
 typedef enum fastd_packet_type {
 	PACKET_HANDSHAKE = 1,	/**< Packet type \em handshake (used to negotiate a session) */
 	PACKET_DATA = 2,	/**< Packet type \em data (used for payload data) */
+	PACKET_KEEPALIVE_REQUEST = 3,	/**< Packet type \em keepalive (used to send and receive a keepalive) */
 } fastd_packet_type_t;
 
 /** The supported modes of operation */

--- a/src/types.h
+++ b/src/types.h
@@ -61,6 +61,7 @@ typedef enum fastd_packet_type {
 	PACKET_HANDSHAKE = 1,	/**< Packet type \em handshake (used to negotiate a session) */
 	PACKET_DATA = 2,	/**< Packet type \em data (used for payload data) */
 	PACKET_KEEPALIVE_REQUEST = 3,	/**< Packet type \em keepalive (used to send and receive a keepalive) */
+	PACKET_KEEPALIVE_REPLY = 4,	/**< Packet type \em keepalive (used to send and receive a keepalive) */
 } fastd_packet_type_t;
 
 /** The supported modes of operation */


### PR DESCRIPTION
* Free memory of packets with an unknown type to avoid leaking if we receive junk/badformed packets
* Free keepalive request/replies
* Creates a keepalive request/reply to save cell radio power by sending a reply on request and keeping the radio traffic to a single interval
* Increase timeouts and jitter intervals to better fit a cell world
* Add config file timeout options